### PR TITLE
Remove trailing comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/xbill82/backbone-relational-jsonapi"
-  },
+  }
 }


### PR DESCRIPTION
Trailing comma in `package.json` prevents installing `backbone-relational-jsonapi` as an NPM dependency:

```
npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 23:1
npm ERR! }
```
